### PR TITLE
(#23) Pre-built OpenCV bindings

### DIFF
--- a/lib/provider/opencv/image-processor.class.ts
+++ b/lib/provider/opencv/image-processor.class.ts
@@ -1,4 +1,4 @@
-import * as cv from "opencv4nodejs";
+import * as cv from "opencv4nodejs-prebuilt";
 import { Image } from "../../image.class";
 import { Region } from "../../region.class";
 

--- a/lib/provider/opencv/image-reader.class.ts
+++ b/lib/provider/opencv/image-reader.class.ts
@@ -1,4 +1,4 @@
-import * as cv from "opencv4nodejs";
+import * as cv from "opencv4nodejs-prebuilt";
 import { Image } from "../../image.class";
 import { DataSource } from "./data-source.interface";
 

--- a/lib/provider/opencv/image-writer.class.ts
+++ b/lib/provider/opencv/image-writer.class.ts
@@ -1,4 +1,4 @@
-import * as cv from "opencv4nodejs";
+import * as cv from "opencv4nodejs-prebuilt";
 import { Image } from "../../image.class";
 import { DataSink } from "./data-sink.interface";
 import { ImageProcessor } from "./image-processor.class";

--- a/lib/provider/opencv/template-matching-finder.class.ts
+++ b/lib/provider/opencv/template-matching-finder.class.ts
@@ -1,4 +1,4 @@
-import * as cv from "opencv4nodejs";
+import * as cv from "opencv4nodejs-prebuilt";
 import * as path from "path";
 import { Image } from "../../image.class";
 import { MatchRequest } from "../../match-request.class";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3657,6 +3657,11 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
+    },
     "native-node-utils": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/native-node-utils/-/native-node-utils-0.1.5.tgz",
@@ -3874,22 +3879,56 @@
         "npmlog": "^4.1.2"
       }
     },
-    "opencv4nodejs": {
+    "opencv4nodejs-prebuilt": {
       "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/opencv4nodejs/-/opencv4nodejs-4.14.1.tgz",
-      "integrity": "sha512-gKXhCL0Atgql7Dr9/5N/iRwcwfcLaQ0eaCbtB/c/g5LXm3slN9Yl/U0bkqKvsorHhseiMyzAzpverxc/zzDpIw==",
+      "resolved": "https://registry.npmjs.org/opencv4nodejs-prebuilt/-/opencv4nodejs-prebuilt-4.14.1.tgz",
+      "integrity": "sha512-MuFCgggCPFVeyen5B0CQQ9VKf2IR5FRMq1x/8fAkv7d+w2FbU8mTqhYxi4EA4T8J66vWG+HOdyv8VHafL9g/sA==",
       "requires": {
         "@types/node": ">6",
         "macro-inferno": "^0.2.3",
         "nan": "^2.12.1",
         "native-node-utils": "^0.1.5",
-        "opencv-build": "^0.0.17"
+        "opencv-build": "^0.0.17",
+        "prebuild-install": "^5.2.4"
       },
       "dependencies": {
+        "expand-template": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+          "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
         "nan": {
           "version": "2.12.1",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
           "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+        },
+        "prebuild-install": {
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.4.tgz",
+          "integrity": "sha512-CG3JnpTZXdmr92GW4zbcba4jkDha6uHraJ7hW4Fn8j0mExxwOKK20hqho8ZuBDCKYCHYIkFM1P2jhtG+KpP4fg==",
+          "requires": {
+            "detect-libc": "^1.0.3",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^2.7.0",
+            "noop-logger": "^0.1.1",
+            "npmlog": "^4.0.1",
+            "os-homedir": "^1.0.1",
+            "pump": "^2.0.1",
+            "rc": "^1.2.7",
+            "simple-get": "^2.7.0",
+            "tar-fs": "^1.13.0",
+            "tunnel-agent": "^0.6.0",
+            "which-pm-runs": "^1.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nut-tree/nut-js",
-  "version": "0.0.4",
+  "version": "0.1.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "win32"
   ],
   "cpu": [
-    "arm",
     "x64",
     "ia32"
   ],
@@ -56,7 +55,7 @@
   },
   "dependencies": {
     "clipboardy": "^1.2.3",
-    "opencv4nodejs": "^4.14.1",
+    "opencv4nodejs-prebuilt": "^4.14.1",
     "robotjs": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR (temporarily) switches from `opencv4nodejs` to `opencv4nodejs-prebuilt`, a fork which provides pre-built bindings to speedup installation.