### PR TITLE
Maintenance/163/provider default export

### DIFF
--- a/lib/adapter/native.adapter.class.spec.ts
+++ b/lib/adapter/native.adapter.class.spec.ts
@@ -1,11 +1,11 @@
 import { Button } from "../button.enum";
 import { Key } from "../key.enum";
 import { Point } from "../point.class";
-import { ClipboardAction } from "../provider/native/clipboardy-clipboard-action.class";
-import { KeyboardAction } from "../provider/native/libnut-keyboard-action.class";
-import { MouseAction } from "../provider/native/libnut-mouse-action.class";
 import { NativeAdapter } from "./native.adapter.class";
-import { WindowAction } from "../provider/native/libnut-window-action.class";
+import ClipboardAction from "../provider/native/clipboardy-clipboard-action.class";
+import KeyboardAction from "../provider/native/libnut-keyboard-action.class";
+import MouseAction from "../provider/native/libnut-mouse-action.class";
+import WindowAction from "../provider/native/libnut-window-action.class";
 
 jest.mock("../provider/native/clipboardy-clipboard-action.class");
 jest.mock("../provider/native/libnut-mouse-action.class");

--- a/lib/adapter/native.adapter.class.ts
+++ b/lib/adapter/native.adapter.class.ts
@@ -2,14 +2,14 @@ import { Button } from "../button.enum";
 import { Key } from "../key.enum";
 import { Point } from "../point.class";
 import { ClipboardActionProvider } from "../provider/native/clipboard-action-provider.interface";
-import { ClipboardAction } from "../provider/native/clipboardy-clipboard-action.class";
 import { KeyboardActionProvider } from "../provider/native/keyboard-action-provider.interface";
 import { MouseActionProvider } from "../provider/native/mouse-action-provider.interface";
-import { KeyboardAction } from "../provider/native/libnut-keyboard-action.class";
-import { MouseAction } from "../provider/native/libnut-mouse-action.class";
 import { Region } from "../region.class";
 import { WindowActionProvider } from "../provider/native/window-action-provider.interface";
-import { WindowAction } from "../provider/native/libnut-window-action.class";
+import ClipboardAction from "../provider/native/clipboardy-clipboard-action.class";
+import KeyboardAction from "../provider/native/libnut-keyboard-action.class";
+import MouseAction from "../provider/native/libnut-mouse-action.class";
+import WindowAction from "../provider/native/libnut-window-action.class";
 
 /**
  * {@link NativeAdapter} serves as an abstraction layer for all OS level interactions.

--- a/lib/adapter/vision.adapter.class.spec.ts
+++ b/lib/adapter/vision.adapter.class.spec.ts
@@ -1,7 +1,7 @@
 import { Image } from "../image.class";
 import { MatchRequest } from "../match-request.class";
-import { ScreenAction } from "../provider/native/libnut-screen-action.class";
-import { TemplateMatchingFinder } from "../provider/opencv/template-matching-finder.class";
+import ScreenAction from "../provider/native/libnut-screen-action.class";
+import TemplateMatchingFinder from "../provider/opencv/template-matching-finder.class";
 import { Region } from "../region.class";
 import { VisionAdapter } from "./vision.adapter.class";
 

--- a/lib/adapter/vision.adapter.class.ts
+++ b/lib/adapter/vision.adapter.class.ts
@@ -1,12 +1,12 @@
 import { Image } from "../image.class";
 import { MatchRequest } from "../match-request.class";
 import { MatchResult } from "../match-result.class";
-import { ScreenAction } from "../provider/native/libnut-screen-action.class";
+import ScreenAction from "../provider/native/libnut-screen-action.class";
 import { ScreenActionProvider } from "../provider/native/screen-action-provider.interface";
 import { DataSink } from "../provider/opencv/data-sink.interface";
 import { FinderInterface } from "../provider/opencv/finder.interface";
 import { ImageWriter } from "../provider/opencv/image-writer.class";
-import { TemplateMatchingFinder } from "../provider/opencv/template-matching-finder.class";
+import TemplateMatchingFinder from "../provider/opencv/template-matching-finder.class";
 import { Region } from "../region.class";
 
 /**

--- a/lib/provider/native/clipboardy-clipboard-action.class.spec.ts
+++ b/lib/provider/native/clipboardy-clipboard-action.class.spec.ts
@@ -1,4 +1,4 @@
-import { ClipboardAction } from "./clipboardy-clipboard-action.class";
+import ClipboardAction from "./clipboardy-clipboard-action.class";
 
 beforeEach(() => {
   jest.resetAllMocks();

--- a/lib/provider/native/clipboardy-clipboard-action.class.ts
+++ b/lib/provider/native/clipboardy-clipboard-action.class.ts
@@ -1,7 +1,7 @@
 import clippy from "clipboardy";
 import { ClipboardActionProvider } from "./clipboard-action-provider.interface";
 
-export class ClipboardAction implements ClipboardActionProvider {
+export default class implements ClipboardActionProvider {
   constructor() {
   }
 

--- a/lib/provider/native/libnut-keyboard-action.class.ts
+++ b/lib/provider/native/libnut-keyboard-action.class.ts
@@ -2,7 +2,7 @@ import libnut = require("@nut-tree/libnut");
 import { Key } from "../../key.enum";
 import { KeyboardActionProvider } from "./keyboard-action-provider.interface";
 
-export class KeyboardAction implements KeyboardActionProvider {
+export default class KeyboardAction implements KeyboardActionProvider {
 
   public static KeyLookupMap = new Map<Key, string | null>([
     [Key.A, "a"],

--- a/lib/provider/native/libnut-keyboard.action.class.spec.ts
+++ b/lib/provider/native/libnut-keyboard.action.class.spec.ts
@@ -1,6 +1,6 @@
 import libnut = require("@nut-tree/libnut");
 import { Key } from "../../key.enum";
-import { KeyboardAction } from "./libnut-keyboard-action.class";
+import KeyboardAction from "./libnut-keyboard-action.class";
 
 jest.mock("@nut-tree/libnut");
 

--- a/lib/provider/native/libnut-mouse-action.class.spec.ts
+++ b/lib/provider/native/libnut-mouse-action.class.spec.ts
@@ -1,7 +1,7 @@
 import libnut = require("@nut-tree/libnut");
 import { Button } from "../../button.enum";
 import { Point } from "../../point.class";
-import { MouseAction } from "./libnut-mouse-action.class";
+import MouseAction from "./libnut-mouse-action.class";
 
 jest.mock("@nut-tree/libnut");
 

--- a/lib/provider/native/libnut-mouse-action.class.ts
+++ b/lib/provider/native/libnut-mouse-action.class.ts
@@ -3,7 +3,7 @@ import { Button } from "../../button.enum";
 import { Point } from "../../point.class";
 import { MouseActionProvider } from "./mouse-action-provider.interface";
 
-export class MouseAction implements MouseActionProvider {
+export default class MouseAction implements MouseActionProvider {
   public static buttonLookup(btn: Button): any {
     return this.ButtonLookupMap.get(btn);
   }

--- a/lib/provider/native/libnut-screen-action.class.spec.ts
+++ b/lib/provider/native/libnut-screen-action.class.spec.ts
@@ -1,6 +1,6 @@
 import libnut = require("@nut-tree/libnut");
 import { Region } from "../../region.class";
-import { ScreenAction } from "./libnut-screen-action.class";
+import ScreenAction from "./libnut-screen-action.class";
 
 jest.mock("@nut-tree/libnut");
 

--- a/lib/provider/native/libnut-screen-action.class.ts
+++ b/lib/provider/native/libnut-screen-action.class.ts
@@ -3,7 +3,7 @@ import { Image } from "../../image.class";
 import { Region } from "../../region.class";
 import { ScreenActionProvider } from "./screen-action-provider.interface";
 
-export class ScreenAction implements ScreenActionProvider {
+export default class ScreenAction implements ScreenActionProvider {
 
   private static determinePixelDensity(
     screen: Region,

--- a/lib/provider/native/libnut-window-action.class.spec.ts
+++ b/lib/provider/native/libnut-window-action.class.spec.ts
@@ -1,5 +1,5 @@
 import libnut = require("@nut-tree/libnut");
-import {WindowAction} from "./libnut-window-action.class";
+import WindowAction from "./libnut-window-action.class";
 import {Region} from "../../region.class";
 
 jest.mock("@nut-tree/libnut");

--- a/lib/provider/native/libnut-window-action.class.ts
+++ b/lib/provider/native/libnut-window-action.class.ts
@@ -2,7 +2,7 @@ import libnut = require("@nut-tree/libnut");
 import { Region } from "../../region.class";
 import { WindowActionProvider } from "./window-action-provider.interface";
 
-export class WindowAction implements WindowActionProvider {
+export default class WindowAction implements WindowActionProvider {
   public getWindows(): Promise<number[]> {
     return new Promise<number[]>((resolve, reject) => {
       try {

--- a/lib/provider/opencv/template-matching-finder.class.spec.ts
+++ b/lib/provider/opencv/template-matching-finder.class.spec.ts
@@ -3,7 +3,7 @@ import {Image} from "../../image.class";
 import {MatchRequest} from "../../match-request.class";
 import {Region} from "../../region.class";
 import {ImageReader} from "./image-reader.class";
-import {TemplateMatchingFinder} from "./template-matching-finder.class";
+import TemplateMatchingFinder from "./template-matching-finder.class";
 
 describe("Template-matching finder", () => {
     it("findMatch should return a match when present in image", async () => {

--- a/lib/provider/opencv/template-matching-finder.class.ts
+++ b/lib/provider/opencv/template-matching-finder.class.ts
@@ -60,7 +60,7 @@ function isValidSearch(needle: cv.Mat, haystack: cv.Mat): boolean {
     return (needle.cols <= haystack.cols) && (needle.rows <= haystack.rows);
 }
 
-export class TemplateMatchingFinder implements FinderInterface {
+export default class TemplateMatchingFinder implements FinderInterface {
     private initialScale = [1.0];
     private scaleSteps = [0.9, 0.8, 0.7, 0.6, 0.5];
 


### PR DESCRIPTION
This PR changes provider modules to use default exports.
This way, adapters do only need to change import paths to switch providers.