### PR TITLE
(#174) Cancel interval timer creation

### DIFF
--- a/lib/util/poll-action.function.spec.ts
+++ b/lib/util/poll-action.function.spec.ts
@@ -118,4 +118,28 @@ describe("poll-action", () => {
         expect(action).toBeCalledTimes(1);
         expect((end - start)).toBeLessThan(updateInterval);
     });
+
+    it("should fail if action does not resolve within timeout", async () => {
+        // GIVEN
+        const updateInterval = 100;
+        const maxDuration = 200;
+        const action = jest.fn(() => {
+            return new Promise((_, reject) => {
+                setTimeout(() => reject(), 300);
+            })
+        });
+
+        // WHEN
+        const start = Date.now();
+        try {
+            await timeout(updateInterval, maxDuration, action);
+        } catch (e) {
+            expect(e).toEqual(`Action timed out after ${maxDuration} ms`);
+        }
+        const end = Date.now();
+
+        // THEN
+        expect(action).toBeCalledTimes(1);
+        expect((end - start)).toBeGreaterThanOrEqual(maxDuration);
+    });
 });

--- a/lib/util/poll-action.function.ts
+++ b/lib/util/poll-action.function.ts
@@ -1,41 +1,45 @@
 export function timeout<R>(updateIntervalMs: number, maxDurationMs: number, action: (...params: any) => Promise<R>): Promise<R> {
   return new Promise<R>((resolve, reject) => {
     let interval: NodeJS.Timeout;
-    const maxTimeout = setTimeout(
-      () => {
-        clearTimeout(maxTimeout);
-        if (interval) {
-          clearTimeout(interval);
-        }
-        reject(`Action timed out after ${maxDurationMs} ms`);
-      },
-      maxDurationMs
-    );
-    const startInterval = () => {
-      interval = setTimeout(function intervalFunc() {
-        action().then((result) => {
-          if (!result) {
-            interval = setTimeout(intervalFunc, updateIntervalMs);
-          } else {
-            clearTimeout(maxTimeout);
-            clearTimeout(interval);
-            resolve(result);
-          }
-        }).catch(() => {
-          interval = setTimeout(intervalFunc, updateIntervalMs);
-        });
-      }, updateIntervalMs);
-    };
+    let timerCleaned = false
 
-    action().then((result) => {
+    function executeInterval() {
+      action().then(validateResult).catch(handleRejection);
+    }
+
+    function validateResult(result: R){
       if (!result) {
-        startInterval();
+        interval = setTimeout(executeInterval, updateIntervalMs);
       } else {
-        clearTimeout(maxTimeout);
+        cleanupTimer();
         resolve(result);
       }
-    }).catch(() => {
-      startInterval();
-    });
+    }
+
+    function handleRejection() {
+      if(!timerCleaned){
+        interval = setTimeout(executeInterval, updateIntervalMs);
+      }
+    }
+
+    function cleanupTimer(){
+      timerCleaned = true
+      if(maxTimeout){
+        clearTimeout(maxTimeout);
+      }
+      if(interval){
+        clearTimeout(interval);
+      }
+    }
+
+    const maxTimeout = setTimeout(
+        () => {
+          cleanupTimer();
+          reject(`Action timed out after ${maxDurationMs} ms`);
+        },
+        maxDurationMs
+    );
+
+    executeInterval()
   });
 }


### PR DESCRIPTION
Hiho! :wave: 

This fixes #174. 

Unfortunately, the test won't reproduce the issue by a failing test case directly. Instead, the pipeline would just hang as shown below in case the issue occurs again. One could refactor the timeout function and white-box it a little bit more so that one is able to test the callback functions of the timers but I think this is not worth the effort.

![image](https://user-images.githubusercontent.com/25754312/98537211-36315a00-2289-11eb-9cf3-062cc9fe82a3.png)
