### PR TITLE
Screen.find by Buffer

### DIFF
--- a/index.e2e.spec.ts
+++ b/index.e2e.spec.ts
@@ -44,7 +44,7 @@ const close = async () => {
 describe("E2E screen test", () => {
   it("should throw on invalid images", async () => {
     jest.setTimeout(30000);
-    await expect(screen.find("mouse.png")).rejects.toContain("Failed to load image");
+    await expect(screen.find("mouse.png")).rejects.toHaveProperty("message", "Failed to load image from '/home/runner/work/nut.js/nut.js/mouse.png'");
   });
 });
 

--- a/lib/adapter/vision.adapter.class.spec.ts
+++ b/lib/adapter/vision.adapter.class.spec.ts
@@ -100,6 +100,7 @@ describe("VisionAdapter class", () => {
     const request = new MatchRequest(
       new Image(100, 100, new ArrayBuffer(0), 3),
       "foo",
+      Buffer.from([]),
       new Region(0, 0, 100, 100),
       0.99,
       true);

--- a/lib/match-request.class.spec.ts
+++ b/lib/match-request.class.spec.ts
@@ -9,6 +9,7 @@ describe("MatchRequest", () => {
         new ArrayBuffer(0), 3
       ),
       "foo",
+      Buffer.from([]),
       new Region(
         0,
         0,

--- a/lib/match-request.class.ts
+++ b/lib/match-request.class.ts
@@ -4,7 +4,8 @@ import { Region } from "./region.class";
 export class MatchRequest {
   constructor(
     public readonly haystack: Image,
-    public readonly pathToNeedle: string,
+    public readonly needleId: string,
+    public readonly needleData: Buffer,
     public readonly searchRegion: Region,
     public readonly confidence: number,
     public readonly searchMultipleScales: boolean = true,

--- a/lib/provider/opencv/data-source.interface.ts
+++ b/lib/provider/opencv/data-source.interface.ts
@@ -9,4 +9,5 @@ export interface DataSource {
    * @param path Absolute path to output file
    */
   load(path: string): Promise<any>;
+  decode(data: Buffer): Promise<any>;
 }

--- a/lib/provider/opencv/determine-searchregion.function.spec.ts
+++ b/lib/provider/opencv/determine-searchregion.function.spec.ts
@@ -13,13 +13,15 @@ describe("determineSearchRegion", () => {
         scaleY: 2.0
       }
     });
-    const needlePath = "/path/to/needle";
+    const needleId = "/path/to/needle";
+    const needleData = Buffer.from([]);
     const inputSearchRegion = new Region(0, 0, 100, 100);
     const expectedSearchRegion = new Region(0, 0, 150, 200);
 
     const matchRequest = new MatchRequest(
       imageMock,
-      needlePath,
+      needleId,
+      needleData,
       inputSearchRegion,
       0.99
     );
@@ -40,13 +42,15 @@ describe("determineSearchRegion", () => {
           scaleY
         }
       });
-      const needlePath = "/path/to/needle";
+      const needleId = "/path/to/needle";
+      const needleData = Buffer.from([]);
       const inputSearchRegion = new Region(0, 0, 100, 100);
       const expectedSearchRegion = new Region(0, 0, 100, 100);
 
       const matchRequest = new MatchRequest(
         imageMock,
-        needlePath,
+        needleId,
+        needleData,
         inputSearchRegion,
         0.99
       );

--- a/lib/provider/opencv/image-reader.class.ts
+++ b/lib/provider/opencv/image-reader.class.ts
@@ -13,4 +13,15 @@ export class ImageReader implements DataSource {
       }
     });
   }
+  
+  public async decode(data: Buffer): Promise<Image> {
+    return new Promise<Image>(async (resolve, reject) => {
+      try {
+        const image = await cv.imdecode(data);
+        resolve(new Image(image.cols, image.rows, image.getData(), image.channels));
+      } catch (e) {
+        reject(`Failed to load image`);
+      }
+    });
+  }
 }

--- a/lib/provider/opencv/template-matching-finder.class.spec.ts
+++ b/lib/provider/opencv/template-matching-finder.class.spec.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import {Image} from "../../image.class";
+import { promises as fs } from 'fs'
 import {MatchRequest} from "../../match-request.class";
 import {Region} from "../../region.class";
 import {ImageReader} from "./image-reader.class";
@@ -11,12 +11,13 @@ describe("Template-matching finder", () => {
         const imageLoader = new ImageReader();
         const SUT = new TemplateMatchingFinder();
         const haystackPath = path.resolve(__dirname, "./__mocks__/mouse.png");
-        const needlePath = path.resolve(__dirname, "./__mocks__/needle.png");
+        const needleId = path.resolve(__dirname, "./__mocks__/needle.png");
+        const needleData = await fs.readFile(needleId);
         const haystack = await imageLoader.load(haystackPath);
-        const needle = await imageLoader.load(needlePath);
+        const needle = await imageLoader.load(needleId);
         const minConfidence = 0.99;
         const searchRegion = new Region(0, 0, haystack.width, haystack.height);
-        const matchRequest = new MatchRequest(haystack, needlePath, searchRegion, minConfidence);
+        const matchRequest = new MatchRequest(haystack, needleId, needleData, searchRegion, minConfidence);
         const expectedResult = new Region(16, 31, needle.width, needle.height);
 
         // WHEN
@@ -32,12 +33,13 @@ describe("Template-matching finder", () => {
         const imageLoader = new ImageReader();
         const SUT = new TemplateMatchingFinder();
         const haystackPath = path.resolve(__dirname, "./__mocks__/mouse.png");
-        const needlePath = path.resolve(__dirname, "./__mocks__/needle.png");
+        const needleId = path.resolve(__dirname, "./__mocks__/needle.png");
+        const needleData = await fs.readFile(needleId);
         const haystack = await imageLoader.load(haystackPath);
-        const needle = await imageLoader.load(needlePath);
+        const needle = await imageLoader.load(needleId);
         const minConfidence = 0.99;
         const searchRegion = new Region(10, 20, 140, 100);
-        const matchRequest = new MatchRequest(haystack, needlePath, searchRegion, minConfidence);
+        const matchRequest = new MatchRequest(haystack, needleId, needleData, searchRegion, minConfidence);
         const expectedResult = new Region(6, 11, needle.width, needle.height);
 
         // WHEN
@@ -53,11 +55,12 @@ describe("Template-matching finder", () => {
         const imageLoader = new ImageReader();
         const SUT = new TemplateMatchingFinder();
         const haystackPath = path.resolve(__dirname, "./__mocks__/downloads.png");
-        const needlePath = path.resolve(__dirname, "./__mocks__/coverage.png");
+        const needleId = path.resolve(__dirname, "./__mocks__/coverage.png");
+        const needleData = await fs.readFile(needleId);
         const haystack = await imageLoader.load(haystackPath);
         const minConfidence = 0.99;
         const searchRegion = new Region(0, 0, 320, 72);
-        const matchRequest = new MatchRequest(haystack, needlePath, searchRegion, minConfidence);
+        const matchRequest = new MatchRequest(haystack, needleId, needleData, searchRegion, minConfidence);
         const expectedRejection = new RegExp(`^No match with required confidence ${minConfidence}. Best match: \\d.\\d* at \\(\\d*, \\d*, \\d*, \\d*\\)$`)
 
         // WHEN
@@ -68,37 +71,17 @@ describe("Template-matching finder", () => {
             .toThrowError(expectedRejection);
     });
 
-    it("findMatch should throw on invalid image paths", async () => {
-        // GIVEN
-        const imageLoader = new ImageReader();
-        const SUT = new TemplateMatchingFinder();
-        const pathToNeedle = path.resolve(__dirname, "./__mocks__/mouse.png");
-        const pathToHaystack = "./__mocks__/foo.png";
-        const needle = await imageLoader.load(pathToNeedle);
-        const minConfidence = 0.99;
-        const searchRegion = new Region(0, 0, 100, 100);
-        const haystack = new Image(needle.width, needle.height, needle.data, 3);
-        const matchRequest = new MatchRequest(haystack, pathToHaystack, searchRegion, minConfidence);
-
-        // WHEN
-        const result = SUT.findMatch(matchRequest);
-
-        // THEN
-        await expect(result)
-            .rejects
-            .toThrowError(`Failed to load ${pathToHaystack}. Reason: 'Failed to load image from '${pathToHaystack}''.`);
-    });
-
     it("findMatch should reject, if needle was way lager than the haystack", async () => {
         // GIVEN
         const imageLoader = new ImageReader();
         const SUT = new TemplateMatchingFinder();
         const haystackPath = path.resolve(__dirname, "./__mocks__/mouse.png");
-        const needlePath = path.resolve(__dirname, "./__mocks__/fat-needle.png");
+        const needleId = path.resolve(__dirname, "./__mocks__/fat-needle.png");
+        const needleData = await fs.readFile(needleId);
         const haystack = await imageLoader.load(haystackPath);
         const minConfidence = 0.99;
         const searchRegion = new Region(0, 0, haystack.width, haystack.height);
-        const matchRequest = new MatchRequest(haystack, needlePath, searchRegion, minConfidence);
+        const matchRequest = new MatchRequest(haystack, needleId, needleData, searchRegion, minConfidence);
         const expectedRejection = new Error("The provided image sample is larger than the provided search region")
 
         // WHEN

--- a/lib/provider/opencv/template-matching-finder.class.ts
+++ b/lib/provider/opencv/template-matching-finder.class.ts
@@ -85,16 +85,16 @@ export default class TemplateMatchingFinder implements FinderInterface {
     public async findMatches(matchRequest: MatchRequest, debug: boolean = false): Promise<ScaledMatchResult[]> {
         let needle: cv.Mat;
         try {
-            const needleInput = await this.source.load(matchRequest.pathToNeedle);
+            const needleInput = await this.source.decode(matchRequest.needleData);
             needle = await loadNeedle(needleInput);
         } catch (e) {
             throw new Error(
-                `Failed to load ${matchRequest.pathToNeedle}. Reason: '${e}'.`,
+                `Failed to load ${matchRequest.needleId}. Reason: '${e}'.`,
             );
         }
         if (!needle || needle.empty) {
             throw new Error(
-                `Failed to load ${matchRequest.pathToNeedle}, got empty image.`,
+                `Failed to load ${matchRequest.needleId}, got empty image.`,
             );
         }
         const haystack = await loadHaystack(matchRequest);
@@ -132,7 +132,6 @@ export default class TemplateMatchingFinder implements FinderInterface {
     }
 
     public async findMatch(matchRequest: MatchRequest, debug: boolean = false): Promise<MatchResult> {
-
         const matches = await this.findMatches(matchRequest, debug);
         const potentialMatches = matches
             .filter(match => match.confidence >= matchRequest.confidence);
@@ -146,7 +145,7 @@ export default class TemplateMatchingFinder implements FinderInterface {
                     throw new Error(`No match with required confidence ${matchRequest.confidence}. Best match: ${bestMatch.confidence} at ${bestMatch.location}`)
                 }
             } else {
-                throw new Error(`Unable to locate ${matchRequest.pathToNeedle}, no match!`);
+                throw new Error(`Unable to locate ${matchRequest.needleId}, no match!`);
             }
         }
         return potentialMatches[0];

--- a/lib/screen.class.spec.ts
+++ b/lib/screen.class.spec.ts
@@ -36,11 +36,13 @@ describe("Screen.", () => {
         const visionAdapterMock = new VisionAdapter();
 
         const SUT = new Screen(visionAdapterMock);
-        const imagePath = "test/path/to/image.png";
-        await expect(SUT.find(imagePath)).resolves.toEqual(matchResult.location);
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
+        await expect(SUT.findImage({ id: imageId, data: imageData })).resolves.toEqual(matchResult.location);
         const matchRequest = new MatchRequest(
             expect.any(Image),
-            join(cwd(), imagePath),
+            imageId,
+            imageData,
             searchRegion,
             SUT.config.confidence,
             true);
@@ -56,9 +58,10 @@ describe("Screen.", () => {
 
         const SUT = new Screen(visionAdapterMock);
         const testCallback = jest.fn(() => Promise.resolve());
-        const imagePath = "test/path/to/image.png";
-        SUT.on(imagePath, testCallback);
-        await SUT.find(imagePath);
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
+        SUT.on(imageId, testCallback);
+        await SUT.findImage({ id: imageId, data: imageData });
         expect(testCallback).toBeCalledTimes(1);
         expect(testCallback).toBeCalledWith(matchResult);
     });
@@ -73,10 +76,11 @@ describe("Screen.", () => {
         const SUT = new Screen(visionAdapterMock);
         const testCallback = jest.fn(() => Promise.resolve());
         const secondCallback = jest.fn(() => Promise.resolve());
-        const imagePath = "test/path/to/image.png";
-        SUT.on(imagePath, testCallback);
-        SUT.on(imagePath, secondCallback);
-        await SUT.find(imagePath);
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
+        SUT.on(imageId, testCallback);
+        SUT.on(imageId, secondCallback);
+        await SUT.findImage({ id: imageId, data: imageData });
         for (const callback of [testCallback, secondCallback]) {
             expect(callback).toBeCalledTimes(1);
             expect(callback).toBeCalledWith(matchResult);
@@ -93,10 +97,11 @@ describe("Screen.", () => {
         const visionAdapterMock = new VisionAdapter();
 
         const SUT = new Screen(visionAdapterMock);
-        const imagePath = "test/path/to/image.png";
-        await expect(SUT.find(imagePath))
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
+        await expect(SUT.findImage({ id: imageId, data: imageData }))
             .rejects
-            .toEqual(`No match for ${imagePath}. Required: ${SUT.config.confidence}, given: ${matchResult.confidence}`);
+            .toEqual(`No match for ${imageId}. Required: ${SUT.config.confidence}, given: ${matchResult.confidence}`);
     });
 
     it("should reject when search fails.", async () => {
@@ -108,10 +113,11 @@ describe("Screen.", () => {
         const visionAdapterMock = new VisionAdapter();
 
         const SUT = new Screen(visionAdapterMock);
-        const imagePath = "test/path/to/image.png";
-        await expect(SUT.find(imagePath))
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
+        await expect(SUT.findImage({ id: imageId, data: imageData }))
             .rejects
-            .toEqual(`Searching for ${imagePath} failed. Reason: '${rejectionReason}'`);
+            .toEqual(`Searching for ${imageId} failed. Reason: '${rejectionReason}'`);
     });
 
     it("should override default confidence value with parameter.", async () => {
@@ -126,12 +132,14 @@ describe("Screen.", () => {
 
         const SUT = new Screen(visionAdapterMock);
 
-        const imagePath = "test/path/to/image.png";
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
         const parameters = new LocationParameters(undefined, minMatch);
-        await expect(SUT.find(imagePath, parameters)).resolves.toEqual(matchResult.location);
+        await expect(SUT.findImage({ id: imageId, data: imageData }, parameters)).resolves.toEqual(matchResult.location);
         const matchRequest = new MatchRequest(
             expect.any(Image),
-            join(cwd(), imagePath),
+            imageId,
+            imageData,
             searchRegion,
             minMatch,
             true);
@@ -147,17 +155,19 @@ describe("Screen.", () => {
         });
         const visionAdapterMock = new VisionAdapter();
         const SUT = new Screen(visionAdapterMock);
-        const imagePath = "test/path/to/image.png";
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
         const parameters = new LocationParameters(customSearchRegion);
         const expectedMatchRequest = new MatchRequest(
           expect.any(Image),
-          join(cwd(), imagePath),
+          imageId,
+          imageData,
           customSearchRegion,
           SUT.config.confidence,
           true);
 
         // WHEN
-        await SUT.find(imagePath, parameters);
+        await SUT.findImage({ id: imageId, data: imageData }, parameters);
 
         // THEN
         expect(visionAdapterMock.findOnScreenRegion).toHaveBeenCalledWith(expectedMatchRequest);
@@ -171,17 +181,19 @@ describe("Screen.", () => {
         });
         const visionAdapterMock = new VisionAdapter();
         const SUT = new Screen(visionAdapterMock);
-        const imagePath = "test/path/to/image.png";
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
         const parameters = new LocationParameters(searchRegion, undefined, false);
         const expectedMatchRequest = new MatchRequest(
           expect.any(Image),
-          join(cwd(), imagePath),
+          imageId,
+          imageData,
           searchRegion,
           SUT.config.confidence,
           false);
 
         // WHEN
-        await SUT.find(imagePath, parameters);
+        await SUT.findImage({ id: imageId, data: imageData }, parameters);
 
         // THEN
         expect(visionAdapterMock.findOnScreenRegion).toHaveBeenCalledWith(expectedMatchRequest);
@@ -197,17 +209,19 @@ describe("Screen.", () => {
         });
         const visionAdapterMock = new VisionAdapter();
         const SUT = new Screen(visionAdapterMock);
-        const imagePath = "test/path/to/image.png";
+        const imageId = "test/path/to/image.png";
+        const imageData = Buffer.from([]);
         const parameters = new LocationParameters(customSearchRegion, minMatch);
         const expectedMatchRequest = new MatchRequest(
           expect.any(Image),
-          join(cwd(), imagePath),
+          imageId,
+          imageData,
           customSearchRegion,
           minMatch,
           true);
 
         // WHEN
-        await SUT.find(imagePath, parameters);
+        await SUT.findImage({ id: imageId, data: imageData }, parameters);
 
         // THEN
         expect(visionAdapterMock.findOnScreenRegion).toHaveBeenCalledWith(expectedMatchRequest);
@@ -261,8 +275,8 @@ describe("Screen.", () => {
         const SUT = new Screen(new VisionAdapter());
 
         // WHEN
-        const matchRegion = await SUT.find(
-            "test/path/to/image.png",
+        const matchRegion = await SUT.findImage(
+            { id: "test/path/to/image.png", data: Buffer.from([]) },
             {
                 searchRegion: limitedSearchRegion
             });


### PR DESCRIPTION
Hi there!

This is a very early proof of concept for #204 ~~, definitely not ready to merge yet~~(got it a bit closer to mergeable over the weekend). 

Just wanted throw together a quick and dirty working implementation (I've tested this locally and it seems to be working as expected) in order to iron out the implementation details and kickstart the discussion on what kind of API we want to offer in the final version.

In this version, I've added a separate `screen.findImage` method with an API that accepts the raw buffer data along with a string identifier. A lot of stuff downstream expect to have the string path available for logging, identifying callbacks, etc, so the string identifier acts as a substitute for these use cases since using the raw buffer data there wouldn't make any sense. This `id` could also become useful for as a cache key for the [needle caching](https://github.com/nut-tree/rfc/blob/main/upcomming-major-release/loading-needles-from-fs.md) feature you had planned. Open to other ideas on how to handle this if you had something else in mind though.

For the final API, here are the approaches I've considered:

1. Keep 2 separate methods for finding by buffer vs finding by file path. In this world I'd imagine we may want to use more specific names to avoid confusion and misuse, i.e. `find` -> `findImageFile`, `findImage` -> `findImageData`.

2. Refactor into a single polymorphic `find` method that accepts both image path and the id + buffer.

I'm personally a fan of approach 1, since it gives us a bit more flexibility in how much or little to share between the methods. If in the future we do want to add a single polymorphic find function as an API, that can be added pretty trivially on top of the two separate APIs, whereas if we start with approach 2 and later want to move to approach 1, we'd have to unwind a bunch of internal branching that could end up getting nasty down the line. 

~~In terms of implementation details, I was thinking of maybe changing the find by path version to first read the image file into a Buffer, so both implementations can just use the Buffer-based logic from that point onwards, which would simplify things quite a bit compared to what's currently in the branch where I've copy pasted everything downstream.~~ I went ahead and made this refactor.

Wanted to get your preferences & thoughts on these topics before continuing further. WDYT?