### PR TITLE
Make screen.find() more convenient on high-DPI devices

### DIFF
--- a/lib/match-request.class.ts
+++ b/lib/match-request.class.ts
@@ -8,5 +8,6 @@ export class MatchRequest {
     public readonly searchRegion: Region,
     public readonly confidence: number,
     public readonly searchMultipleScales: boolean = true,
+    public readonly scaleNeedle: number = 1.0,
   ) {}
 }

--- a/lib/optionalsearchparameters.class.ts
+++ b/lib/optionalsearchparameters.class.ts
@@ -10,5 +10,5 @@ export class OptionalSearchParameters {
    * @param confidence Optional confidence value to configure image match confidence
    * @param searchMultipleScales Optional flag to indicate if the search should be conducted at different scales
    */
-  constructor(public searchRegion?: Region, public confidence?: number, public searchMultipleScales?: boolean) {}
+  constructor(public searchRegion?: Region, public confidence?: number, public searchMultipleScales?: boolean, public scaleNeedle?: number) {}
 }

--- a/lib/provider/opencv/template-matching-finder.class.ts
+++ b/lib/provider/opencv/template-matching-finder.class.ts
@@ -97,6 +97,9 @@ export default class TemplateMatchingFinder implements FinderInterface {
                 `Failed to load ${matchRequest.pathToNeedle}, got empty image.`,
             );
         }
+        if (matchRequest.scaleNeedle !== 1.0)
+                needle = await scaleImage(needle, matchRequest.scaleNeedle);
+
         const haystack = await loadHaystack(matchRequest);
 
         if (debug) {

--- a/lib/screen.class.ts
+++ b/lib/screen.class.ts
@@ -87,6 +87,7 @@ export class Screen {
         const searchRegion =
             (params && params.searchRegion) || await this.vision.screenSize();
         const searchMultipleScales = (params && params.searchMultipleScales)
+        const scaleNeedle = (params && params.scaleNeedle) || 1.0;
 
         const fullPathToNeedle = normalize(join(this.config.resourceDirectory, templateImageFilename));
 
@@ -97,7 +98,8 @@ export class Screen {
             fullPathToNeedle,
             searchRegion,
             minMatch,
-            searchMultipleScales
+            searchMultipleScales,
+            scaleNeedle
         );
 
         return new Promise<Region>(async (resolve, reject) => {


### PR DESCRIPTION
When capturing a screen region in a recent Windows version on a high-DPI device, the captured image can have a much higher resolution than scale-unaware applications such as `node.exe` might think (compare also [this PR](https://github.com/nut-tree/libnut/pull/52)).

For convenience, let's support scaling the "needle" image that `nut.js` is told to find.

For example, on my laptop, where the scale factor is 200%, I would capture a rectangular region, save it as a `.png` file, then tell
`nut.js` to find it thusly:

```javascript
await screen.find('needle.png', 10000, { scaleNeedle: true })
```