### PR TITLE
added method to cancel screen waitFor

### DIFF
--- a/docs/classes/screen.html
+++ b/docs/classes/screen.html
@@ -97,6 +97,7 @@
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="screen.html#on" class="tsd-kind-icon">on</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="screen.html#waitfor" class="tsd-kind-icon">wait<wbr>For</a></li>
 								<li class="tsd-kind-method tsd-parent-kind-class"><a href="screen.html#width" class="tsd-kind-icon">width</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="screen.html#cancelwaitfor" class="tsd-kind-icon">cancel<wbr>Wait<wbr>For</a></li>
 							</ul>
 						</section>
 						<section class="tsd-index-section ">
@@ -405,6 +406,37 @@
 						</li>
 					</ul>
 				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
+					<a name="cancelwaitfor" class="tsd-anchor"></a>
+					<h3>cancel<wbr>Wait<wbr>For</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
+						<li class="tsd-signature tsd-kind-icon">cancel<wbr>Wait<wbr>For<span class="tsd-signature-symbol">(</span>templateImageFilename<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/nut-tree/nut.js/blob/90e5072/lib/screen.class.ts#L193">screen.class.ts:144</a></li>
+								</ul>
+							</aside>
+							<div class="tsd-comment tsd-typography">
+								<div class="lead">
+									<p><a href="screen.html#cancelwaitfor">cancelWaitFor</a> cancels a waitFor for any given template image</p>
+								</div>
+							</div>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>templateImageFilename: <span class="tsd-signature-type">string</span></h5>
+									<div class="tsd-comment tsd-typography">
+										<p>Filename of the template image to cancel waitFor of, relative to <a href="screen.html#config.resourcedirectory">Screen.config.resourceDirectory</a></p>
+									</div>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">&gt;</span></h4>
+						</li>
+					</ul>
+				</section>
 			</section>
 			<section class="tsd-panel-group tsd-member-group ">
 				<h2>Object literals</h2>
@@ -538,6 +570,9 @@
 							</li>
 							<li class=" tsd-kind-method tsd-parent-kind-class">
 								<a href="screen.html#width" class="tsd-kind-icon">width</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class">
+								<a href="screen.html#cancelwaitfor" class="tsd-kind-icon">cancel<wbr>Wait<wbr>For</a>
 							</li>
 							<li class=" tsd-kind-object-literal tsd-parent-kind-class">
 								<a href="screen.html#config" class="tsd-kind-icon">config</a>


### PR DESCRIPTION
It adds a method which will use `EventEmitter` class to cancel respective `screen.waitFor` on the basis of templateImageFileName.