### PR TITLE
Add AbortSignal support to sleep module

### DIFF
--- a/lib/sleep.function.ts
+++ b/lib/sleep.function.ts
@@ -1,5 +1,14 @@
-export const sleep = async (ms: number) => {
-  return new Promise<void>(resolve => setTimeout(resolve, ms));
+import {setTimeout as setTimeoutPromise} from "timers/promises";
+
+export const sleep = async (ms: number, signal?: AbortSignal) => {
+  const options = {signal: {aborted: false}};
+  if (signal) options.signal = signal;
+  return setTimeoutPromise(ms, true, options).catch(err => {
+    if (err.name ==='AbortError') {
+      return Promise.resolve(true);
+    }
+    return Promise.reject(err);
+  });
 };
 
 export const busyWaitForNanoSeconds = (duration: number) => {


### PR DESCRIPTION
Currently, the sleep module waits for the entire timeout before returning with no way of aborting. For similar feature parity with the waitFor abort option, it makes sense for sleep to be able to be aborted as well.