### PR TITLE
Feature/373/macos doubleclick

### DIFF
--- a/lib/mouse.class.ts
+++ b/lib/mouse.class.ts
@@ -221,4 +221,34 @@ export class MouseClass {
             }
         });
     }
+
+    /**
+     * {@link click} clicks a mouse button
+     * @param btn The {@link Button} to click
+     */
+    public async click(btn: Button): Promise<MouseClass> {
+        return new Promise<MouseClass>(async (resolve, reject) => {
+            try {
+                await this.providerRegistry.getMouse().click(btn);
+                resolve(this);
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
+
+    /**
+     * {@link doubleClick} performs a double click on a mouse button
+     * @param btn The {@link Button} to click
+     */
+    public async doubleClick(btn: Button): Promise<MouseClass> {
+        return new Promise<MouseClass>(async (resolve, reject) => {
+            try {
+                await this.providerRegistry.getMouse().doubleClick(btn);
+                resolve(this);
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
 }

--- a/lib/provider/mouse-provider.interface.ts
+++ b/lib/provider/mouse-provider.interface.ts
@@ -27,6 +27,20 @@ export interface MouseProviderInterface {
   currentMousePosition(): Promise<Point>;
 
   /**
+   * click should allow to perform a single click via OS event
+   *
+   * @param btn The {@link Button} to click
+   */
+  click(btn: Button): Promise<void>;
+
+  /**
+   * doubleClick should allow to perform a double click via OS event
+   *
+   * @param btn The {@link Button} to click
+   */
+  doubleClick(btn: Button): Promise<void>;
+
+  /**
    * leftClick should allow to perform a left click via OS event
    */
   leftClick(): Promise<void>;

--- a/lib/provider/native/libnut-mouse.class.ts
+++ b/lib/provider/native/libnut-mouse.class.ts
@@ -1,7 +1,7 @@
 import libnut = require("@nut-tree/libnut");
-import { Button } from "../../button.enum";
-import { Point } from "../../point.class";
-import { MouseProviderInterface } from "../mouse-provider.interface";
+import {Button} from "../../button.enum";
+import {Point} from "../../point.class";
+import {MouseProviderInterface} from "../mouse-provider.interface";
 
 export default class MouseAction implements MouseProviderInterface {
   public static buttonLookup(btn: Button): any {
@@ -41,37 +41,38 @@ export default class MouseAction implements MouseProviderInterface {
     }));
   }
 
-  public leftClick(): Promise<void> {
+  public click(btn: Button): Promise<void> {
     return new Promise<void>(((resolve, reject) => {
       try {
-        libnut.mouseClick(MouseAction.buttonLookup(Button.LEFT));
+        libnut.mouseClick(MouseAction.buttonLookup(btn));
         resolve();
       } catch (e) {
         reject(e);
       }
     }));
+  }
+
+  public doubleClick(btn: Button): Promise<void> {
+    return new Promise<void>(((resolve, reject) => {
+      try {
+        libnut.mouseClick(MouseAction.buttonLookup(btn), true);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    }));
+  }
+
+  public leftClick(): Promise<void> {
+    return this.click(Button.LEFT);
   }
 
   public rightClick(): Promise<void> {
-    return new Promise<void>(((resolve, reject) => {
-      try {
-        libnut.mouseClick(MouseAction.buttonLookup(Button.RIGHT));
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    }));
+    return this.click(Button.RIGHT);
   }
 
   public middleClick(): Promise<void> {
-    return new Promise<void>(((resolve, reject) => {
-      try {
-        libnut.mouseClick(MouseAction.buttonLookup(Button.MIDDLE));
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    }));
+    return this.click(Button.MIDDLE);
   }
 
   public pressButton(btn: Button): Promise<void> {


### PR DESCRIPTION
This PR is the second part to fix #373 

It exposes two new methods on the `mouse` public API:

- `click`
- `doubleClick`