### PR TITLE
Feature/400/fetch images from url

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -52,6 +52,7 @@ const loadImage = providerRegistry.getImageReader().load;
 const saveImage = providerRegistry.getImageWriter().store;
 
 const imageResource = (fileName: string) => loadImageResource(providerRegistry, screen.config.resourceDirectory, fileName);
+export {fetchFromUrl} from "./lib/imageResources.function";
 
 export {
     clipboard,

--- a/lib/imageResources.function.spec.ts
+++ b/lib/imageResources.function.spec.ts
@@ -1,8 +1,9 @@
-import {loadImageResource} from "./imageResources.function";
+import {fetchFromUrl, loadImageResource} from "./imageResources.function";
 import {mockPartial} from "sneer";
 import {ProviderRegistry} from "./provider/provider-registry.class";
 import {ImageReader} from "./provider";
 import {join} from "path";
+import {ColorMode} from "./colormode.enum";
 
 const loadMock = jest.fn();
 const providerRegistryMock = mockPartial<ProviderRegistry>({
@@ -24,5 +25,47 @@ describe('imageResources', () => {
 
         // THEN
         expect(loadMock).toBeCalledWith(join(resourceDirectoryPath, imageFileName));
+    });
+});
+
+describe('fetchFromUrl', () => {
+    it('should throw on malformed URLs', async () => {
+        // GIVEN
+        const malformedUrl = "foo";
+
+        // WHEN
+        const SUT = () => fetchFromUrl(malformedUrl);
+
+        // THEN
+        await expect(SUT).rejects.toThrowError("Invalid URL");
+    });
+
+    it('should throw on non-image URLs', async () => {
+        // GIVEN
+        const nonImageUrl = 'https://www.npmjs.com/package/jimp';
+
+        // WHEN
+        const SUT = () => fetchFromUrl(nonImageUrl);
+
+        // THEN
+        await expect(SUT).rejects.toThrowError('Could not find MIME for Buffer');
+    });
+
+    it('should return an RGB image from a valid URL', async () => {
+        // GIVEN
+        const validImageUrl = 'https://github.com/nut-tree/nut.js/raw/master/.gfx/nut.png';
+        const expectedDimensions = {
+            width: 502,
+            height: 411
+        };
+        const expectedColorMode = ColorMode.RGB;
+
+        // WHEN
+        const rgbImage = await fetchFromUrl(validImageUrl);
+
+        // THEN
+        expect(rgbImage.colorMode).toBe(expectedColorMode);
+        expect(rgbImage.width).toBe(expectedDimensions.width);
+        expect(rgbImage.height).toBe(expectedDimensions.height);
     });
 });

--- a/lib/imageResources.function.ts
+++ b/lib/imageResources.function.ts
@@ -1,7 +1,38 @@
 import {join, normalize} from "path";
 import {ProviderRegistry} from "./provider/provider-registry.class";
+import {URL} from "url";
+import {Image} from "./image.class";
+import Jimp from "jimp";
+import {ColorMode} from "./colormode.enum";
 
 export function loadImageResource(providerRegistry: ProviderRegistry, resourceDirectory: string, fileName: string) {
     const fullPath = normalize(join(resourceDirectory, fileName));
     return providerRegistry.getImageReader().load(fullPath);
+}
+
+export async function fetchFromUrl(url: string | URL): Promise<Image> {
+    let imageUrl: URL;
+    if (url instanceof URL) {
+        imageUrl = url;
+    } else {
+        try {
+            imageUrl = new URL(url);
+        } catch (e) {
+            throw e;
+        }
+    }
+    return Jimp.read(imageUrl.href)
+        .then((image) => {
+            return new Image(
+                image.bitmap.width,
+                image.bitmap.height,
+                image.bitmap.data,
+                4,
+                imageUrl.href,
+                ColorMode.RGB
+            );
+        })
+        .catch(err => {
+            throw err;
+        });
 }

--- a/lib/imageResources.function.ts
+++ b/lib/imageResources.function.ts
@@ -10,6 +10,11 @@ export function loadImageResource(providerRegistry: ProviderRegistry, resourceDi
     return providerRegistry.getImageReader().load(fullPath);
 }
 
+/**
+ * fetchFromUrl loads remote image content at runtime to provide it for further use in on-screen image search
+ * @param url The remote URl to fetch an image from as string or {@link URL}
+ * @throws On malformed URL input or in case of non-image remote content
+ */
 export async function fetchFromUrl(url: string | URL): Promise<Image> {
     let imageUrl: URL;
     if (url instanceof URL) {


### PR DESCRIPTION
This PR introduces a new public API function that enables users to fetch image content from remote hosts.

This is particularly useful for on-screen image search as you are no longer required to keep all template images locally, but are now able to manage them in a central, shared storage.