### PR TITLE
Fix grave accent

### DIFF
--- a/lib/provider/native/libnut-keyboard.class.ts
+++ b/lib/provider/native/libnut-keyboard.class.ts
@@ -92,7 +92,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
         [Key.RightShift, "space"],
         [Key.RightSuper, "command"],
 
-        [Key.Grave, "~"],
+        [Key.Grave, "`"],
         [Key.Minus, "-"],
         [Key.Equal, "="],
         [Key.Backspace, "backspace"],


### PR DESCRIPTION
Grave accent isn't working for me on MacOS 11.6. This fixed it for me. Not sure if there are subtleties on Windows or Linux.

https://github.com/nut-tree/libnut/blob/bc9af7200c8e08b6eb9dc6547c81256b48fb1016/src/linux/keycode.c#L38