### PR TITLE
adding support for Clear key on mac added in libnut fa2b880

### DIFF
--- a/lib/key.enum.ts
+++ b/lib/key.enum.ts
@@ -113,6 +113,7 @@ export enum Key {
   Divide,
   Decimal,
   Enter,
+  Clear,
 
   NumPad0,
   NumPad1,

--- a/lib/provider/native/libnut-keyboard.class.ts
+++ b/lib/provider/native/libnut-keyboard.class.ts
@@ -131,6 +131,7 @@ export default class KeyboardAction implements KeyboardProviderInterface {
     [Key.Multiply, "multiply"],
     [Key.Divide, "divide"],
     [Key.Enter, "enter"],
+    [Key.Clear, "clear"],
 
     [Key.CapsLock, "caps_lock"],
     [Key.ScrollLock, "scroll_lock"],


### PR DESCRIPTION
I believe I have added support for the Clear key I added to libnut, but have not tested it, as I'm not sure how to use both local builds together... Please let me know if you see any problems.